### PR TITLE
Fix windows installation on CI

### DIFF
--- a/install_prerequisites.py
+++ b/install_prerequisites.py
@@ -4,7 +4,7 @@ import os
 
 def run_command(command):
   try:
-    subprocess.check_call(command, shell=True)
+    subprocess.check_call(command)
   except subprocess.CalledProcessError as e:
     print(f"Error occurred: {e}")
     sys.exit(1)
@@ -21,19 +21,27 @@ def install_pip():
     if os.path.exists(get_pip_script):
       os.remove(get_pip_script)
 
+def check_and_install(package, constraint):
+  try:
+    pkg = __import__(package)
+    # Skip version check for simplicity, as we are ensuring the constraint is applied on installation
+    print(f"{package} is already installed.")
+  except ImportError:
+    print(f"Installing {package} with constraint {constraint}.")
+    run_command(f"{sys.executable} -m pip install {package}{constraint}")
+
 def main():
   try:
-    print("python -m pop --version")
+    print("python -m pip --version")
     subprocess.check_call([sys.executable, "-m", "pip", "--version"])
   except subprocess.CalledProcessError:
     print("install pip")
     install_pip()
 
-  requirements_file = os.path.join(os.path.dirname(__file__),
-          'mbedtls/csources/scripts/driver.requirements.txt')
-  print(f"{sys.executable} -m pip install -r {requirements_file}")
-  run_command(f"{sys.executable} -m pip install -r {requirements_file}")
-
+  # Check and install markupsafe, Jinja2 and jsonschema
+  check_and_install("markupsafe", "<2.1")
+  check_and_install("jinja2", ">=2.10.3")
+  check_and_install("jsonschema", "<4.18.0")
 
 if __name__ == "__main__":
   main()

--- a/install_prerequisites.py
+++ b/install_prerequisites.py
@@ -12,7 +12,7 @@ def run_command(command):
 def install_pip():
   get_pip_script = "get-pip.py"
   try:
-    run_command(f"curl -s https://bootstrap.pypa.io/get-pip.py -o {get_pip_script}")
+    run_command(f"curl https://bootstrap.pypa.io/get-pip.py -o {get_pip_script}")
     run_command(f"{sys.executable} {get_pip_script}")
   except Exception as e:
     print(f"Failed to install pip: {e}")
@@ -27,10 +27,9 @@ def main():
   except subprocess.CalledProcessError:
     install_pip()
 
-  # Check and install Jinja2 and jsonschema
   requirements_file = os.path.join(os.path.dirname(__file__),
           'mbedtls/csources/scripts/driver.requirements.txt')
-  run_command(f"{sys.executable} -m pip --quiet install -r {requirements_file}")
+  run_command(f"{sys.executable} -m pip install -r {requirements_file}")
 
 
 if __name__ == "__main__":

--- a/install_prerequisites.py
+++ b/install_prerequisites.py
@@ -23,12 +23,15 @@ def install_pip():
 
 def main():
   try:
+    print("python -m pop --version")
     subprocess.check_call([sys.executable, "-m", "pip", "--version"])
   except subprocess.CalledProcessError:
+    print("install pip")
     install_pip()
 
   requirements_file = os.path.join(os.path.dirname(__file__),
           'mbedtls/csources/scripts/driver.requirements.txt')
+  print(f"{sys.executable} -m pip install -r {requirements_file}")
   run_command(f"{sys.executable} -m pip install -r {requirements_file}")
 
 


### PR DESCRIPTION
Windows installation on CI was failing mainly due to the auto-generating code in Mbed-TLS using python packages with unusual requirements (rust for example).
This PR should fix it.